### PR TITLE
added a waiter which fixes a bug  

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,10 @@ class Table {
 
     try {
       await this.db.createTable(params).promise()
+
+      const waitParams = { TableName: params.TableName }
+
+      await this.db.waitFor('tableExists', waitParams).promise()
     } catch (err) {
       if (err.name !== 'ResourceInUseException') {
         return resolve({ err })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raziel",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "",
   "bin": "bin/raziel",
   "main": "index.js",


### PR DESCRIPTION
if you call open() with createIfExists and the table doesnt exist AND you try to write immediately afterwards, the write call will be attempted before the table is finished being provisioned by AWS, this fixes that to make raziel wait for the table before returning from the open() call